### PR TITLE
[#41] Add dependency to use collectAsStateWithLifecycle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,7 @@ dependencies {
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.core:core-splashscreen:${Versions.ANDROIDX_CORE_SPLASH_SCREEN_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
     implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     implementation("androidx.compose.ui:ui")

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,12 +15,12 @@ object Versions {
     const val ANDROIDX_ANNOTATION_VERSION = "1.3.0"
     const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
     const val ANDROIDX_CORE_SPLASH_SCREEN_VERSION = "1.0.0"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.0-rc01"
     const val ANDROIDX_SLICE_VERSION = "1.0.0"
 
     const val CHUCKER_VERSION = "3.5.2"
     const val COMPOSE_BOM_VERSION = "2022.12.00"
-    const val COMPOSE_COMPILER_VERSION = "1.3.2"
+    const val COMPOSE_COMPILER_VERSION = "1.4.3"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
@@ -28,7 +28,7 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_VERSION = "1.7.20"
+    const val KOTLIN_VERSION = "1.8.10"
     const val KOTLINX_COROUTINES_VERSION = "1.6.4"
     const val KOVER_VERSION = "0.6.0"
 


### PR DESCRIPTION
- Closes #41 

## What happened 👀

- Add dependency `androidx.lifecycle:lifecycle-runtime-compose` to use `collectAsStateWithLifeCycle()`
- Replace `collectAsState()` to `collectAsStateWithLifeCycle()` in `HomeScreen`

## Insight 📝

To use `androidx.lifecycle:lifecycle-runtime-compose` version `2.6.0-rc01`, we need to update the following libs versions:
- **androidx.lifecycle:lifecycle-runtime-ktx** from `2.5.1` to `2.6.0-rc01` to use the same version for lifecycle lib
- **kotlin version** from `1.7.20` to `1.8.10`
- **compose compiler version** from `1.3.2` to `1.4.3`
- 
## Proof Of Work 📹

The application runs normally.

[41.webm](https://user-images.githubusercontent.com/12026942/222669859-1c7885d5-3005-488e-9cf2-87422cd1058a.webm)
