### PR TITLE
[Chore] Update detekt rules to ignore LongMethod and MagicNumber for Composable annotation

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -68,6 +68,7 @@ complexity:
   LongMethod:
     active: true
     threshold: 60
+    ignoreAnnotated: [ 'Composable' ]
   LongParameterList:
     active: true
     functionThreshold: 5
@@ -205,7 +206,7 @@ naming:
     active: true
     constantPattern: '[A-Z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][A-Za-z0-9]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][A-Za-z0-9]*'
   VariableMaxLength:
     active: false
     maximumVariableNameLength: 64
@@ -293,6 +294,7 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+    ignoreAnnotated: [ 'Composable' ]
   MaxLineLength:
     active: true
     maxLineLength: 120


### PR DESCRIPTION
## What happened 👀

- Update detekt configure follows by This [PR](https://github.com/nimblehq/android-templates/pull/413/files)
- Currently, there are a lot of `LongMethod` for the Composable function. We can ignore those warnings for our project to include implementation speed. And for the `MagicNumber` warnings, sometimes we have to specify a dimension that uses only one screen. So it also makes sense to ignore the `MagicNumver` warning for the Composable function.

## Insight 📝

Here is the log from the github workflow before updating: 

![Screenshot 2566-03-08 at 8 56 46 PM](https://user-images.githubusercontent.com/12026942/223731827-b1ada9a9-4f9b-4f1d-ae97-445b9f59688b.png)

![Screenshot 2566-03-08 at 8 56 54 PM](https://user-images.githubusercontent.com/12026942/223731973-58a64d0d-74e9-4ad5-a9b2-cb2ec1181670.png)

## Proof Of Work 📹

None
